### PR TITLE
Cleaner sd_vector_builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ As [SDSL 2](https://github.com/simongog/sdsl-lite) is no longer maintained, vgte
 
 ## Tools/libraries using this fork
 
-- [ ] [VG](https://github.com/vgteam/vg)
+- [x] [VG](https://github.com/vgteam/vg)
 - [x] [GBWT](https://github.com/jltsiren/gbwt)
 - [x] [GBWTGraph](https://github.com/jltsiren/gbwtgraph)
 - [x] [GCSA2](https://github.com/jltsiren/gcsa2)

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -51,7 +51,7 @@ template<typename, typename, typename>
 class sd_vector;  // in sd_vector
 
 //! Class for in-place construction of sd_vector from a strictly increasing sequence
-/*! \par Building an sd_vector will clear the builder.
+/*! \par Building an `sd_vector` will clear the builder.
  */
 class sd_vector_builder
 {
@@ -76,23 +76,22 @@ class sd_vector_builder
         //! Constructor
         /*! \param n Vector size.
          *  \param m The number of 1-bits.
+         *  \par Throws `std::runtime_error` if `m > n`.
          */
         sd_vector_builder(size_type n, size_type m);
 
-        inline size_type size() const { return m_size; }
-        inline size_type capacity() const { return m_capacity; }
-        inline size_type tail() const { return m_tail; }
-        inline size_type items() const { return m_items; }
+        size_type size() const { return m_size; }
+        size_type capacity() const { return m_capacity; }
+        size_type tail() const { return m_tail; }
+        size_type items() const { return m_items; }
 
         //! Set a bit to 1.
         /*! \param i The position of the bit.
          *  \par The position must be strictly greater than for the previous call.
+         *  Behavior is undefined if the position is out of range or the vector is full.
          */
-        inline void set(size_type i)
+        void set(size_type i) noexcept
         {
-            assert(i >= m_tail && i < m_size);
-            assert(m_items < m_capacity);
-
             size_type cur_high = i >> m_wl;
             m_highpos += (cur_high - m_last_high);
             m_last_high = cur_high;
@@ -100,6 +99,13 @@ class sd_vector_builder
             m_high[m_highpos++] = 1;  // write 1 for the entry
             m_tail = i + 1;
         }
+
+        //! Set a bit to 1.
+        /*! \param i The position of the bit.
+         *  \par The position must be strictly greater than for the previous call.
+         *  Throws `std::runtime_error` if the position is out of range or the vector is full.
+         */
+        void set_safe(size_type i);
 
         //! Swap method
         void swap(sd_vector_builder& sdb);
@@ -110,7 +116,7 @@ class sd_vector_builder
 /*!
  * \par Other implementations of this data structure:
  *  - the sdarray of Okanohara and Sadakane
- *  - Sebastiano Vigna implemented a elias_fano class in this sux library.
+ *  - Sebastiano Vigna implemented a elias_fano class in the sux library.
  *
  * \par References
  *  - P. Elias: ,,Efficient storage and retrieval by content and address of static files'',
@@ -265,6 +271,11 @@ class sd_vector
             util::init_support(m_high_0_select, &m_high);
         }
 
+        //! Transforms the `sd_vector_builder` into `sd_vector`.
+        /*!
+         *  \par Empties the builder.
+         *  Throws `std::runtime_error` if the builder is not full.
+         */
         sd_vector(sd_vector_builder& builder)
         {
             if (builder.items() != builder.capacity()) {

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -90,7 +90,7 @@ class sd_vector_builder
          *  \par The position must be strictly greater than for the previous call.
          *  Behavior is undefined if the position is out of range or the vector is full.
          */
-        void set(size_type i) noexcept
+        void set_unsafe(size_type i) noexcept
         {
             size_type cur_high = i >> m_wl;
             m_highpos += (cur_high - m_last_high);
@@ -105,7 +105,19 @@ class sd_vector_builder
          *  \par The position must be strictly greater than for the previous call.
          *  Throws `std::runtime_error` if the position is out of range or the vector is full.
          */
-        void set_safe(size_type i);
+        void set(size_type i)
+        {
+            if (m_items >= m_capacity) {
+                throw std::runtime_error("sd_vector_builder::set(): the builder is already full.");
+            }
+            if (i < m_tail) {
+                throw std::runtime_error("sd_vector_builder::set(): the position is too small.");
+            }
+            if (i >= m_size) {
+                throw std::runtime_error("sd_vector_builder::set(): the position is too large.");
+            }
+            this->set_unsafe(i);
+        }
 
         //! Swap method
         void swap(sd_vector_builder& sdb);

--- a/lib/sd_vector.cpp
+++ b/lib/sd_vector.cpp
@@ -35,22 +35,6 @@ sd_vector_builder::sd_vector_builder(size_type n, size_type m) :
 }
 
 void
-sd_vector_builder::set_safe(size_type i)
-{
-    if (m_items >= m_capacity) {
-        throw std::runtime_error("sd_vector_builder::set(): the builder is already full.");
-    }
-    if (i < m_tail) {
-        throw std::runtime_error("sd_vector_builder::set(): the position is too small.");
-    }
-    if (i >= m_size) {
-        throw std::runtime_error("sd_vector_builder::set(): the position is too large.");
-    }
-
-    this->set(i);
-}
-
-void
 sd_vector_builder::swap(sd_vector_builder& sdb)
 {
     std::swap(m_size, sdb.m_size);

--- a/lib/sd_vector.cpp
+++ b/lib/sd_vector.cpp
@@ -19,21 +19,35 @@ sd_vector_builder::sd_vector_builder(size_type n, size_type m) :
     m_tail(0), m_items(0),
     m_last_high(0), m_highpos(0)
 {
-    if(m_capacity > m_size)
-    {
+    if (m_capacity > m_size) {
         throw std::runtime_error("sd_vector_builder: requested capacity is larger than vector size.");
     }
 
     size_type logm = bits::hi(m_capacity) + 1;
     const size_type logn = bits::hi(m_size) + 1;
-    if(logm == logn)
-    {
+    if(logm == logn) {
         --logm; // to ensure logn-logm > 0
         assert(logn - logm > 0);
     }
     m_wl = logn - logm;
     m_low = int_vector<>(m_capacity, 0, m_wl);
     m_high = bit_vector(m_capacity + (1ULL << logm), 0);
+}
+
+void
+sd_vector_builder::set_safe(size_type i)
+{
+    if (m_items >= m_capacity) {
+        throw std::runtime_error("sd_vector_builder::set(): the builder is already full.");
+    }
+    if (i < m_tail) {
+        throw std::runtime_error("sd_vector_builder::set(): the position is too small.");
+    }
+    if (i >= m_size) {
+        throw std::runtime_error("sd_vector_builder::set(): the position is too large.");
+    }
+
+    this->set(i);
 }
 
 void
@@ -53,9 +67,8 @@ sd_vector_builder::swap(sd_vector_builder& sdb)
 template<>
 sd_vector<>::sd_vector(sd_vector_builder& builder)
 {
-    if(builder.items() != builder.capacity())
-    {
-      throw std::runtime_error("sd_vector: the builder is not full.");
+    if(builder.items() != builder.capacity()) {
+      throw std::runtime_error("sd_vector: the builder is not at full capacity.");
     }
 
     m_size = builder.m_size;

--- a/test/sd_vector_test.cpp
+++ b/test/sd_vector_test.cpp
@@ -15,10 +15,7 @@ class sd_vector_test : public ::testing::Test { };
 
 using testing::Types;
 
-typedef Types<
-sd_vector<>,
-          sd_vector<rrr_vector<63>>
-          > Implementations;
+typedef Types< sd_vector<>, sd_vector<rrr_vector<63>> > Implementations;
 
 TYPED_TEST_CASE(sd_vector_test, Implementations);
 
@@ -72,6 +69,32 @@ TYPED_TEST(sd_vector_test, builder_empty_constructor)
     TypeParam sdv(builder);
     for (size_t i=0; i < BV_SIZE; ++i) {
         ASSERT_FALSE((bool)sdv[i]);
+    }
+}
+
+TYPED_TEST(sd_vector_test, builder_exceptions)
+{
+    {
+        // Too many ones.
+        ASSERT_THROW(sd_vector_builder(1024, 1025), std::runtime_error);
+    }
+    {
+        // Position is too small.
+        sd_vector_builder builder(1024, 3);
+        builder.set(128);
+        ASSERT_THROW(builder.set_safe(128), std::runtime_error);
+    }
+    {
+        // Position is too large.
+        sd_vector_builder builder(1024, 3);
+        ASSERT_THROW(builder.set_safe(1024), std::runtime_error);
+    }
+    {
+        // Not full.
+        sd_vector_builder builder(1024, 3);
+        builder.set(128);
+        builder.set(256);
+        ASSERT_THROW(TypeParam{builder}, std::runtime_error);
     }
 }
 

--- a/test/sd_vector_test.cpp
+++ b/test/sd_vector_test.cpp
@@ -82,12 +82,12 @@ TYPED_TEST(sd_vector_test, builder_exceptions)
         // Position is too small.
         sd_vector_builder builder(1024, 3);
         builder.set(128);
-        ASSERT_THROW(builder.set_safe(128), std::runtime_error);
+        ASSERT_THROW(builder.set(128), std::runtime_error);
     }
     {
         // Position is too large.
         sd_vector_builder builder(1024, 3);
-        ASSERT_THROW(builder.set_safe(1024), std::runtime_error);
+        ASSERT_THROW(builder.set(1024), std::runtime_error);
     }
     {
         // Not full.


### PR DESCRIPTION
`sd_vector_builder` is now cleaner and better documented.

The old `set()` implementation relied on assertions for correctness. Because SDSL is compiled with `-DNDEBUG` by default, the assertions usually didn't do anything. This was a bit confusing (see simongog/sdsl-lite#430).

Now there are two versions of `set()`:

* `set_unsafe()` skips all sanity checks and assumes that the user knows what they are doing.
* `set()` throws `std::runtime_error` if the position is out of range or the builder is already full.

The exceptions thrown by `sd_vector_builder` and `sd_vector` constructors have also been documented.