### PR TITLE
Run-length encoded bitvector

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As [SDSL 2](https://github.com/simongog/sdsl-lite) is no longer maintained, vgte
 
 - [x] Switch to C++14.
 - [x] `sd_vector` improvements: iterator over set bits and support for predecessor/successor queries.
-- [ ] `rle_vector`: a run-length encoded bitvector.
+- [x] `rle_vector`: a run-length encoded bitvector.
 
 
 ## Tools/libraries using this fork

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ As [SDSL 2](https://github.com/simongog/sdsl-lite) is no longer maintained, vgte
 
 - [x] Switch to C++14.
 - [x] `sd_vector` improvements: iterator over set bits and support for predecessor/successor queries.
+- [ ] `rle_vector`: a run-length encoded bitvector.
+
 
 ## Tools/libraries using this fork
 

--- a/include/sdsl/bit_vectors.hpp
+++ b/include/sdsl/bit_vectors.hpp
@@ -10,5 +10,6 @@
 #include "rrr_vector.hpp"
 #include "sd_vector.hpp"
 #include "hyb_vector.hpp"
+#include "rle_vector.hpp"
 
 #endif

--- a/include/sdsl/bits.hpp
+++ b/include/sdsl/bits.hpp
@@ -125,6 +125,9 @@ struct bits {
     */
     static uint32_t lo(uint64_t x);
 
+    //! Length of the binary encoding of integer x.
+    static uint32_t length(uint64_t x) { return hi(x) + 1; };
+
     //! Counts the number of 1-bits in the 32bit integer x.
     /*! This function is a variant of the method cnt. If
     	32bit multiplication is fast, this method beats the cnt.

--- a/include/sdsl/rle_vector.hpp
+++ b/include/sdsl/rle_vector.hpp
@@ -1,0 +1,645 @@
+#ifndef INCLUDED_SDSL_RLE_VECTOR
+#define INCLUDED_SDSL_RLE_VECTOR
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+#include "sd_vector.hpp"
+
+//! Namespace for the succinct data structure library
+namespace sdsl
+{
+
+//-----------------------------------------------------------------------------
+
+// Forward declarations.
+
+template<uint8_t t_b = 1, uint64_t t_block_size = 64>
+class rank_support_rle;
+
+template<uint64_t t_block_size = 64>
+class select_support_rle;
+
+//-----------------------------------------------------------------------------
+
+//! A growable bit-packed integer array that consists of fixed-size blocks.
+/*!
+ * \tparam t_block_bytes  Number of bytes per block. Must be at least 16 and a multiple of 8.
+ * \tparam t_element_bits Number of bits per element. Must be a factor of 64.
+ */
+template<uint64_t t_block_bytes, uint64_t t_element_bits>
+class block_array
+{
+    public:
+        typedef bit_vector::size_type size_type;
+        typedef uint64_t value_type;
+
+    private:
+        std::vector<value_type> data;
+
+        static_assert(t_block_bytes >= 16, "block_array: block size must be at least 16 bytes.");
+        static_assert(t_block_bytes % 8 == 0, "block_array: block size must be a multiple of 8 bytes.");
+        static_assert(t_element_bits > 0 && 64 % t_element_bits == 0, "block_array: element size must be a factor of 64 bits.");
+
+    public:
+        //! Returns the size of the array in elements.
+        size_type size() const { return this->data.size() * (64 / t_element_bits); }
+
+        //! Returns the value of element i.
+        value_type operator[](size_type i) const {
+            i *= t_element_bits;
+            return (this->data[i / 64] >> (i & 63)) & bits::lo_set[t_element_bits];
+        }
+
+        //! Sets the value of element i.
+        void set(size_type i, value_type value) {
+            i *= t_element_bits;
+            this->data[i / 64] &= ~(bits::lo_set[t_element_bits] << (i & 63));
+            this->data[i / 64] |= (value & bits::lo_set[t_element_bits]) << (i & 63);
+        }
+
+        //! Adds a new block to the array.
+        void add_block() {
+            this->data.resize(this->data.size() + (8 * t_block_bytes / t_element_bits), 0);
+        }
+
+        //! Serializes the data structure into the given ostream.
+        size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+        {
+            structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+            size_type written_bytes = 0;
+
+            size_type len = this->data.size();
+            written_bytes += write_member(len, out);
+            size_type offset = 0;
+            while (offset < this->data.size()) {
+                size_type words = std::min(this->data.size() - offset, conf::SDSL_BLOCK_SIZE / sizeof(uint64_t));
+                out.write((const char*)(this->data.data() + offset), words * sizeof(uint64_t));
+                written_bytes += words * sizeof(uint64_t);
+                offset += words;
+            }
+ 
+            structure_tree::add_size(child, written_bytes);
+            return written_bytes;
+        }
+
+        //! Loads the data structure from the given istream.
+        void load(std::istream& in)
+        {
+            size_type len = 0;
+            read_member(len, in);
+            this->data.resize(len, 0);
+
+            size_type offset = 0;
+            while (offset < this->data.size()) {
+                size_type words = std::min(this->data.size() - offset, conf::SDSL_BLOCK_SIZE / sizeof(uint64_t));
+                in.read((char*)(this->data.data() + offset), words * sizeof(uint64_t));
+                offset += words;
+            }
+        }
+
+        //! Swap method.
+        void swap(block_array& another) {
+            this->data.swap(another.data);
+        }
+};
+
+//-----------------------------------------------------------------------------
+
+// TODO: Common interface with sd_vector_builder; use as rle_vector::builder_type?
+//! Class for in-place construction of rle_vector from a strictly increasing sequence.
+/*!
+ * \tparam t_block_size Number of elements in a block. Must be a multiple of 32.
+ * \par Building a `rle_vector` will clear the builder.
+ */
+template<uint64_t t_block_size = 64>
+class rle_vector_builder
+{
+    public:
+        typedef sd_vector<>::size_type size_type;
+
+    private:
+        size_type run_start, run_length;
+
+        size_type length;    // Final length of the bitvector.
+        size_type total_bits, set_bits;
+
+        block_array<t_block_size / 2, 4> body;
+        size_type body_tail; // Next unused position in the body.
+
+        std::vector<size_type> block_bits, block_ones;
+
+        constexpr static size_type DATA_MASK = 0x7;
+        constexpr static size_type NEXT_ELEM = 0x8;
+        constexpr static size_type DATA_BITS = 3;
+
+        static_assert(t_block_size >= 32 && t_block_size % 32 == 0, "rle_vector_builder: block size must be a positive multiple of 32.");
+
+    public:
+        //! Creates a builder for a rle_vector of length n.
+        explicit rle_vector_builder(size_type n) :
+            run_start(0), run_length(0),
+            length(n), total_bits(0), set_bits(0),
+            body_tail(0)
+        {
+        }
+
+        //! Returns the length of the bitvector.
+        size_type size() const { return this->length; }
+
+        //! Returns the first bitvector position that can be set.
+        size_type tail() const { return this->run_start + this->run_length; }
+
+        //! Appends one or more 1s to the bitvector.
+        /*! \param i The position of the first 1.
+         *  \param n Number of bits to append.
+         *  \par The position must be strictly greater than the last set bit.
+         *  Behavior is undefined if the position is out of range or if `n == 0`.
+         */
+        void set_unsafe(size_type i, size_type n = 1) noexcept
+        {
+            if (i == this->tail()) { this->run_length += n; }
+            else {
+                this->write_run();
+                this->run_start = i; this->run_length = n;
+            }
+        }
+
+        //! Appends one or more 1s to the bitvector.
+        /*! \param i The position of the first 1.
+         *  \param n Number of bits to append.
+         *  \par The position must be strictly greater than the last set bit.
+         *  Throws `std::runtime_error` if the position is out of range.
+         */
+        void set(size_type i, size_type n = 1)
+        {
+            if (n == 0) { return; }
+            if (i < this->tail()) {
+                throw std::runtime_error("rle_vector_builder::set(): the position is too small.");
+            }
+            if (i + n > this->size()) {
+                throw std::runtime_error("sd_vector_builder::set(): the position is too large.");
+            }
+            this->set_unsafe(i, n);
+        }
+
+    private:
+        template<typename> friend class rle_vector;
+
+        void add_block() {
+            this->body.add_block();
+            this->block_bits.push_back(this->total_bits);
+            this->block_ones.push_back(this->set_bits);
+        }
+
+        // Is there enough space in the current block to encode `value`?
+        bool fits_in_current_block(size_type value) {
+            size_type needed = (bits::length(value) + DATA_BITS - 1) / DATA_BITS;
+            return (this->body.size() - this->body_tail >= needed);
+        }
+
+        // Append the value to the body, assuming that it fits into the current block.
+        void write(size_type value) {
+            while (value > DATA_MASK) {
+                this->body.set(this->body_tail, (value & DATA_MASK) | NEXT_ELEM);
+                this->body_tail++; value >>= DATA_BITS;
+            }
+            this->body.set(this->body_tail, value);
+            this->body_tail++;
+        }
+
+        // Add 0s until position `i`. Note that this creates a new run of 0s.
+        void add_zeros_until(size_type i) {
+            size_type zero_run = i - this->total_bits;
+            if (!this->fits_in_current_block(zero_run)) {
+                this->add_block();
+            }
+            this->write(zero_run);
+            this->total_bits = i;
+        }
+
+        // Append the current run to the bitvector if its length is nonzero.
+        void write_run() {
+            if (this->run_length == 0) { return; }
+
+            // Write the run of 0s.
+            this->add_zeros_until(this->run_start);
+
+            // Write the run of 1s.
+            if (!this->fits_in_current_block(this->run_length - 1)) {
+                this->add_block();
+                this->write(0); // A block always starts with a run of 0s.
+            }
+            this->write(this->run_length - 1);
+            this->total_bits += this->run_length;
+            this->set_bits += this->run_length;
+
+            this->run_start = this->total_bits;
+            this->run_length = 0;
+        }
+
+        // Finish the construction. Further bits cannot be set after this.
+        void flush() {
+            this->write_run();
+            if (this->total_bits < this->size()) { this->add_zeros_until(this->size()); }
+        }
+};
+
+//-----------------------------------------------------------------------------
+
+//! A bitvector that uses run-length encoding.
+/*!
+ * \par The overall design is related to the bitvectors used in RLCSA.
+ * The body of the bitvector consists of an alternating sequence of runs of 0s and 1s.
+ * Run lengths are encoded using elements of 4 bits (3 bits of data + carry bit).
+ * Runs of 0s are encoded as is, while runs of 1s are encoded as (length - 1).
+ * The runs are divided into blocks of `t_block_size` elements (default 64).
+ * Two `sd_vector`s are used for storing the number of bits and 1s before each block.
+ *
+ * \par References
+ *  - V. Mäkinen, G. Navarro, J. Sirén, N. Välimäki:
+ *    ,, Storage and Retrieval of Highly Repetitive Sequence Collections'',
+ *    Journal of Computational Biology, 2010.
+ * 
+ * \tparam t_block_size Number of elements in a block. Must be a multiple of 32.
+*/
+template<uint64_t t_block_size = 64>
+class rle_vector
+{
+    // Definitions.
+
+    public:
+        typedef bit_vector::size_type                    size_type;
+        typedef size_type                                value_type;
+        typedef bit_vector::difference_type              difference_type;
+        typedef random_access_const_iterator<rle_vector> iterator;
+        typedef iterator                                 const_iterator;
+        typedef bv_tag                                   index_category;
+
+        typedef rank_support_rle<0, t_block_size>        rank_0_type;
+        typedef rank_support_rle<1, t_block_size>        rank_1_type;
+        typedef select_support_rle<t_block_size>         select_1_type;
+
+    private:
+        block_array<t_block_size / 2, 4> body;
+        sd_vector<> block_bits; // Marks the first bit in each block.
+        sd_vector<> block_ones; // Marks the first one in each block.
+
+        constexpr static size_type DATA_MASK = 0x7;
+        constexpr static size_type NEXT_ELEM = 0x8;
+        constexpr static size_type DATA_BITS = 3;
+
+        static_assert(t_block_size >= 32 && t_block_size % 32 == 0, "rle_vector: block size must be a positive multiple of 32.");
+
+//-----------------------------------------------------------------------------
+
+    // Standard interface.
+
+    public:
+        rle_vector() {}
+        rle_vector(const rle_vector& source) { this->copy(source); }
+        rle_vector(rle_vector&& source) { *this = std::move(source); }
+
+        rle_vector& operator=(const rle_vector& source)
+        {
+            if (this != &source) { this->copy(source); }
+            return *this;
+        }
+
+        rle_vector& operator=(rle_vector&& source)
+        {
+            if (this != &source) {
+                this->body = std::move(source.body);
+                this->block_bits = std::move(source.block_bits);
+                this->block_ones = std::move(source.block_ones);
+            }
+            return *this;
+        }
+
+        //! Swap method
+        void swap(rle_vector& another)
+        {
+            if (this != &another) {
+                this->body.swap(another.body);
+                this->block_bits.swap(another.block_bits);
+                this->block_ones.swap(another.block_ones);
+            }
+        }
+
+        //! Serializes the data structure into the given ostream.
+        size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+        {
+            structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+            size_type written_bytes = 0;
+            written_bytes += this->body.serialize(out, child, "body");
+            written_bytes += this->block_bits.serialize(out, child, "block_bits");
+            written_bytes += this->block_ones.serialize(out, child, "block_ones");
+            structure_tree::add_size(child, written_bytes);
+            return written_bytes;
+        }
+
+        //! Loads the data structure from the given istream.
+        void load(std::istream& in)
+        {
+            this->body.load(in);
+            this->block_bits.load(in);
+            this->block_ones.load(in);
+        }
+
+//-----------------------------------------------------------------------------
+
+    // Main constructors.
+
+    public:
+
+        //! Create a run-length encoded copy of the source bitvector.
+        rle_vector(const bit_vector& source)
+        {
+            rle_vector_builder<t_block_size> builder(source.size());
+            for (size_type i = 0; i < source.size(); i++) {
+                if (source[i]) { builder.set_unsafe(i); }
+            }
+            *this = rle_vector(builder);
+        }
+
+        //! Convert the data in the builder into a `rle_vector`.
+        /*!
+         * \par Construction clears the builder.
+         */
+        rle_vector(rle_vector_builder<t_block_size>& builder)
+        {
+            builder.flush();
+            this->body = std::move(builder.body);
+
+            {
+                sd_vector_builder bits_builder(builder.total_bits, builder.block_bits.size());
+                for (auto pos : builder.block_bits) { bits_builder.set_unsafe(pos); }
+                this->block_bits = sd_vector<>(bits_builder);
+            }
+
+            {
+                sd_vector_builder ones_builder(builder.set_bits, builder.block_ones.size());
+                for (auto pos : builder.block_ones) { ones_builder.set_unsafe(pos); }
+                this->block_ones = sd_vector<>(ones_builder);
+            }
+        }
+
+//-----------------------------------------------------------------------------
+
+    // Operations.
+
+    public:
+
+        //! Returns the i-th element of the bitvector.
+        /*! \param i Position in the bitvector.
+         */
+        value_type operator[](size_type i) const
+        {
+            if (i >= this->size()) { return 0; }
+
+            auto sample = *(this->block_bits.predecessor(i));
+            size_type body_offset = sample.first * t_block_size;
+            size_type bv_offset = sample.second;
+            while (true) {
+                bv_offset += this->run_length(body_offset); // Run of 0s.
+                if (bv_offset > i) { return 0; }
+                bv_offset += this->run_length(body_offset) + 1; // Run of 1s.
+                if (bv_offset > i) { return 1; }
+            }
+        }
+
+        //! Returns the integer value of the binary string of length len starting at position i.
+        /*!
+         * \param i   Starting position in the bitvector.
+         * \param len Length of the binary string (1 to 64).
+         * \par Behavior is undefined if `len` is invalid.
+         */
+        uint64_t get_int(size_type i, size_type len = 64) const
+        {
+            if (i >= this->size()) { return 0; }
+            len = std::min(len, this->size() - i);
+
+            auto sample = *(this->block_bits.predecessor(i));
+            size_type body_offset = sample.first * t_block_size;
+            size_type bv_offset = sample.second;
+            uint64_t value = 0;
+
+            // Skip unused bits.
+            while (true) {
+                bv_offset += this->run_length(body_offset); // Run of 0s.
+                if (bv_offset >= i) { break; }
+                bv_offset += this->run_length(body_offset) + 1; // Run of 1s.
+                if (bv_offset >= i) { value = bits::lo_set[std::min(bv_offset - i, len)]; break; }
+            }
+
+            // Read the actual bits.
+            while (true) {
+                bv_offset += this->run_length(body_offset); // Run of 0s.
+                if (bv_offset >= i + len) { break; }
+                size_type one_run = std::min(this->run_length(body_offset) + 1, i + len - bv_offset); // Run of 1s.
+                value |= bits::lo_set[one_run] << (bv_offset - i);
+                bv_offset += one_run;
+                if (bv_offset >= i + len) { break; }
+            }
+
+            return value;
+        }
+
+        // TODO predecessor, successor?
+
+//-----------------------------------------------------------------------------
+
+    // Iterators and statistics.
+
+    public:
+        iterator begin() const { return iterator(this, 0); }
+        iterator end() const { return iterator(this, this->size()); }
+
+        // TODO iterator over runs?
+
+        //! Returns the length of the bitvector.
+        size_type size() const { return this->block_bits.size(); }
+
+        //! Returns the number of ones in the bitvector.
+        size_type ones() const { return this->block_ones.size(); }
+
+        // TODO runs()?
+
+//-----------------------------------------------------------------------------
+
+    // Internal implementation.
+
+    private:
+        template<uint8_t, uint64_t> friend class rank_support_rle;
+        template<uint64_t> friend class select_support_rle;
+
+        void copy(const rle_vector& another)
+        {
+            this->body = another.body;
+            this->block_bits = another.block_bits;
+            this->block_ones = another.block_ones;
+        }
+
+        // Returns the (raw) length of the run starting at `body[i]`.
+        size_type run_length(size_type& i) const
+        {
+            size_type offset = 0;
+            size_type result = this->body[i] & DATA_MASK;
+            while (this->body[i] & NEXT_ELEM != 0) {
+                i++; offset += DATA_BITS;
+                result += (this->body[i] & DATA_MASK) << offset;
+            }
+            i++;
+            return result;
+        }
+};
+
+//-----------------------------------------------------------------------------
+
+template<uint8_t t_b>
+struct rank_support_rle_trait
+{
+    typedef rle_vector<>::size_type size_type;
+    static size_type adjust_rank(size_type r, size_type) { return r; }
+};
+
+template<>
+struct rank_support_rle_trait<0>
+{
+    typedef rle_vector<>::size_type size_type;
+    static size_type adjust_rank(size_type r, size_type n) { return n - r; }
+};
+
+//! Rank data structure for rle_vector.
+/*! \tparam t_b          Bit pattern.
+ *  \tparam t_block_size Block size in the `rle_vector`.
+ */
+template<uint8_t t_b, uint64_t t_block_size>
+class rank_support_rle
+{
+    public:
+        typedef rle_vector<t_block_size> vector_type;
+        typedef typename vector_type::size_type size_type;
+
+        explicit rank_support_rle(const vector_type* v = nullptr) : parent(v) {}
+
+        //! Returns the number of bits of type t_b before position i.
+        /*!
+         * \param i Position in the bitvector.
+         * \par Returns the total number of bits of type `t_b` if `i` is too large.
+         */
+        size_type rank(size_type i) const
+        {
+            if (i >= this->parent->size()) { return this->parent->ones(); }
+
+            auto sample = *(this->parent->block_bits.predecessor(i));
+            size_type body_offset = sample.first * t_block_size;
+            size_type bv_offset = sample.second;
+            size_type result = this->parent->block_ones.select_iter(sample.first + 1)->second;
+            while (true) {
+                bv_offset += this->parent->run_length(body_offset); // Run of 0s.
+                if (bv_offset >= i) { break; }
+                size_type one_run = this->parent->run_length(body_offset) + 1; // Run of 1s.
+                bv_offset += one_run; result += one_run;
+                if (bv_offset >= i) {
+                    result -= bv_offset - i;
+                    break;
+                }
+            }
+
+            return rank_support_rle_trait<t_b>::adjust_rank(result, this->parent->size());
+        }
+
+        size_type operator()(size_type i) const { return this->rank(i); }
+
+        void set_vector(const vector_type* v = nullptr) { this->parent = v; }
+
+        rank_support_rle& operator=(const rank_support_rle& another)
+        {
+            if (this != &another) { this->set_vector(another.parent); }
+            return *this;
+        }
+
+        void swap(rank_support_rle& another) { std::swap(this->parent, another.parent); }
+
+        void load(std::istream&, const vector_type* v = nullptr) { this->set_vector(v); }
+
+        size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+        {
+            return serialize_empty_object(out, v, name, this);
+        }
+
+    private:
+        static_assert(t_b == 1u or t_b == 0u , "rank_support_rle: bit pattern must be `0` or `1`");
+        const vector_type* parent;
+};
+
+//-----------------------------------------------------------------------------
+
+
+//! Select data structure for rle_vector.
+/*! \tparam t_block_size Block size in the `rle_vector`.
+ */
+template<uint64_t t_block_size>
+class select_support_rle
+{
+    public:
+        typedef rle_vector<t_block_size> vector_type;
+        typedef typename vector_type::size_type size_type;
+
+        explicit select_support_rle(const vector_type* v = nullptr) : parent(v) {}
+
+        //! Returns the position of the i-th one in the bitvector.
+        /*!
+         * \param i 1-based rank of the bit.
+         * \par Returns -1 if `i == 0` and the length of the bitvector if `i` is too large.
+         */
+        size_type select(size_type i) const
+        {
+            if (i == 0) { return static_cast<size_type>(-1); }
+            if (i >= this->parent->ones()) { return this->parent->size(); }
+
+            auto sample = *(this->parent->block_ones.predecessor(i - 1)); // select(i) corresponds to block_ones[i - 1].
+            size_type body_offset = sample.first * t_block_size;
+            size_type bv_offset = this->parent->block_bits.select_iter(sample.first + 1)->second;
+            size_type rank = sample.second;
+            while (true) {
+                bv_offset += this->parent->run_length(body_offset); // Run of 0s.
+                size_type one_run = this->parent->run_length(body_offset) + 1; // Run of 1s.
+                bv_offset += one_run; rank += one_run;
+                if (rank > i) {
+                    return bv_offset - (rank - 1 - i);
+                }
+            }
+        }
+
+        size_type operator()(size_type i) const { return this->select(i); }
+
+        void set_vector(const vector_type* v = nullptr) { this->parent = v; }
+
+        select_support_rle& operator=(const select_support_rle& another)
+        {
+            if (this != &another) { this->set_vector(another.parent); }
+            return *this;
+        }
+
+        void swap(select_support_rle& another) { std::swap(this->parent, another.parent); }
+
+        void load(std::istream&, const vector_type* v = nullptr) { this->set_vector(v); }
+
+        size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+        {
+            return serialize_empty_object(out, v, name, this);
+        }
+
+    private:
+        const vector_type* parent;
+};
+
+//-----------------------------------------------------------------------------
+
+} // namespace sdsl
+
+#endif // INCLUDED_SDSL_RLE_VECTOR

--- a/include/sdsl/rle_vector.hpp
+++ b/include/sdsl/rle_vector.hpp
@@ -142,7 +142,7 @@ class rle_vector_builder
 
     public:
         //! Creates a builder for a rle_vector of length n.
-        explicit rle_vector_builder(size_type n) :
+        explicit rle_vector_builder(size_type n = 0) :
             run_start(0), run_length(0),
             length(n), total_bits(0), set_bits(0),
             body_tail(0)
@@ -356,7 +356,6 @@ class rle_vector
     // Main constructors.
 
     public:
-
         //! Create a run-length encoded copy of the source bitvector.
         rle_vector(const bit_vector& source)
         {
@@ -387,6 +386,8 @@ class rle_vector
                 for (auto pos : builder.block_ones) { ones_builder.set_unsafe(pos); }
                 this->block_ones = sd_vector<>(ones_builder);
             }
+
+            builder = builder_type();
         }
 
 //-----------------------------------------------------------------------------
@@ -394,7 +395,6 @@ class rle_vector
     // Operations.
 
     public:
-
         //! Returns the i-th element of the bitvector.
         /*! \param i Position in the bitvector.
          */

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -128,9 +128,10 @@ class sd_vector_builder
 
 //-----------------------------------------------------------------------------
 
-//! An a bidirectional iterator over the set bits in `sd_vector`.
+//! A bidirectional iterator over the set bits in `sd_vector`.
 /*!
  * \par The `value_type` has semantics `(rank(i), i)` or `(i, select(i + 1))`.
+ * Dereferencing an iterator at the end yields `(ones(), size())`.
  */
 template<class t_hi_bit_vector, class t_select_1, class t_select_0>
 class sd_one_iterator
@@ -188,6 +189,9 @@ class sd_one_iterator
                 do { this->high_offset++; }
                 while (!this->parent->high[this->high_offset]);
                 this->set_value();
+            } else {
+                this->value.first = this->low_offset;
+                this->value.second = this->parent->size();
             }
             return *this;
         }

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -54,7 +54,6 @@ class sd_vector;
 
 //-----------------------------------------------------------------------------
 
-// TODO: Common interface with rle_vector_builder; use as sd_vector::builder_type?
 //! Class for in-place construction of sd_vector from a strictly increasing sequence.
 /*! \par Building an `sd_vector` will clear the builder.
  */
@@ -272,6 +271,8 @@ class sd_vector
         typedef select_support_sd<0, t_hi_bit_vector, select_1_support_type, select_0_support_type> select_0_type;
         typedef select_support_sd<1, t_hi_bit_vector, select_1_support_type, select_0_support_type> select_1_type;
 
+        typedef sd_vector_builder builder_type;
+
         typedef sd_one_iterator<t_hi_bit_vector, select_1_support_type, select_0_support_type> one_iterator;
 
         typedef t_hi_bit_vector hi_bit_vector_type;
@@ -402,7 +403,7 @@ class sd_vector
          *  \par Empties the builder.
          *  Throws `std::runtime_error` if the builder is not full.
          */
-        sd_vector(sd_vector_builder& builder)
+        sd_vector(builder_type& builder)
         {
             if (builder.items() != builder.capacity()) {
                 throw std::runtime_error("sd_vector: builder is not at full capacity.");
@@ -415,7 +416,7 @@ class sd_vector
             util::init_support(m_high_1_select, &(this->m_high));
             util::init_support(m_high_0_select, &(this->m_high));
 
-            builder = sd_vector_builder();
+            builder = builder_type();
         }
 
 //-----------------------------------------------------------------------------
@@ -690,7 +691,7 @@ class sd_vector
 };
 
 //! Specialized constructor that is a bit more space-efficient than the default.
-template<> sd_vector<>::sd_vector(sd_vector_builder& builder);
+template<> sd_vector<>::sd_vector(builder_type& builder);
 
 //-----------------------------------------------------------------------------
 

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -35,34 +35,31 @@ namespace sdsl
 
 //-----------------------------------------------------------------------------
 
-// forward declaration needed for friend declaration
+// Forward declarations.
+
 template<uint8_t t_b          = 1,
          class t_hi_bit_vector= bit_vector,
          class t_select_1     = typename t_hi_bit_vector::select_1_type,
          class t_select_0     = typename t_hi_bit_vector::select_0_type>
-class rank_support_sd;  // in sd_vector
+class rank_support_sd;
 
-// forward declaration needed for friend declaration
 template<uint8_t t_b          = 1,
          class t_hi_bit_vector= bit_vector,
          class t_select_1     = typename t_hi_bit_vector::select_1_type,
          class t_select_0     = typename t_hi_bit_vector::select_0_type>
-class select_support_sd;  // in sd_vector
+class select_support_sd;
 
-// forward declaration needed for friend declaration
 template<typename, typename, typename>
 class sd_vector;
 
 //-----------------------------------------------------------------------------
 
-//! Class for in-place construction of sd_vector from a strictly increasing sequence
+// TODO: Common interface with rle_vector_builder; use as sd_vector::builder_type?
+//! Class for in-place construction of sd_vector from a strictly increasing sequence.
 /*! \par Building an `sd_vector` will clear the builder.
  */
 class sd_vector_builder
 {
-        template<typename, typename, typename>
-        friend class sd_vector;
-
     public:
         typedef bit_vector::size_type size_type;
 
@@ -74,6 +71,8 @@ class sd_vector_builder
 
         int_vector<> m_low;
         bit_vector   m_high;
+
+        template<typename, typename, typename> friend class sd_vector;
 
     public:
         sd_vector_builder();
@@ -90,7 +89,7 @@ class sd_vector_builder
         size_type tail() const { return m_tail; }
         size_type items() const { return m_items; }
 
-        //! Set a bit to 1.
+        //! Sets a bit to 1.
         /*! \param i The position of the bit.
          *  \par The position must be strictly greater than for the previous call.
          *  Behavior is undefined if the position is out of range or the vector is full.
@@ -105,7 +104,7 @@ class sd_vector_builder
             m_tail = i + 1;
         }
 
-        //! Set a bit to 1.
+        //! Sets a bit to 1.
         /*! \param i The position of the bit.
          *  \par The position must be strictly greater than for the previous call.
          *  Throws `std::runtime_error` if the position is out of range or the vector is full.
@@ -124,7 +123,7 @@ class sd_vector_builder
             this->set_unsafe(i);
         }
 
-        //! Swap method
+        //! Swap method.
         void swap(sd_vector_builder& sdb);
 };
 
@@ -326,8 +325,8 @@ class sd_vector
         {
             m_size = bv.size();
             size_type m = util::cnt_one_bits(bv);
-            uint8_t logm = bits::hi(m)+1;
-            uint8_t logn = bits::hi(m_size)+1;
+            uint8_t logm = bits::length(m);
+            uint8_t logn = bits::length(m_size);
             if (logm == logn) {
                 --logm;    // to ensure logn-logm > 0
             }
@@ -371,8 +370,8 @@ class sd_vector
             }
             size_type m = std::distance(begin,end);
             m_size = *(end-1)+1;
-            uint8_t logm = bits::hi(m)+1;
-            uint8_t logn = bits::hi(m_size)+1;
+            uint8_t logm = bits::length(m);
+            uint8_t logn = bits::length(m_size);
             if (logm == logn) {
                 --logm;    // to ensure logn-logm > 0
             }
@@ -933,8 +932,8 @@ class select_0_support_sd
                 size_type z = 0;
                 size_type rank1 = 0;// rank1 in H
                 size_type zeros = m_v->size() - rank_1(m_v)(m_v->size()); // zeros in B
-                m_pointer = int_vector<>(zeros/(64*bs)+1, 0, bits::hi(m_v->high.size()/64)+1);
-                m_rank1   = int_vector<>(m_pointer.size(), 0, bits::hi(m_v->high.size())+1);
+                m_pointer = int_vector<>(zeros/(64*bs)+1, 0, bits::length(m_v->high.size()/64));
+                m_rank1   = int_vector<>(m_pointer.size(), 0, bits::length(m_v->high.size()));
                 uint64_t w=0;
                 for (size_type i=0, sel0=1; i < m_v->high.size(); i+=64) {
                     size_type old_rank1 = rank1;

--- a/lib/sd_vector.cpp
+++ b/lib/sd_vector.cpp
@@ -23,8 +23,8 @@ sd_vector_builder::sd_vector_builder(size_type n, size_type m) :
         throw std::runtime_error("sd_vector_builder: requested capacity is larger than vector size.");
     }
 
-    size_type logm = bits::hi(m_capacity) + 1;
-    const size_type logn = bits::hi(m_size) + 1;
+    size_type logm = bits::length(m_capacity);
+    const size_type logn = bits::length(m_size);
     if(logm == logn) {
         --logm; // to ensure logn-logm > 0
         assert(logn - logm > 0);

--- a/lib/sd_vector.cpp
+++ b/lib/sd_vector.cpp
@@ -49,7 +49,7 @@ sd_vector_builder::swap(sd_vector_builder& sdb)
 }
 
 template<>
-sd_vector<>::sd_vector(sd_vector_builder& builder)
+sd_vector<>::sd_vector(builder_type& builder)
 {
     if(builder.items() != builder.capacity()) {
       throw std::runtime_error("sd_vector: the builder is not at full capacity.");
@@ -62,7 +62,7 @@ sd_vector<>::sd_vector(sd_vector_builder& builder)
     util::init_support(m_high_1_select, &m_high);
     util::init_support(m_high_0_select, &m_high);
 
-    builder = sd_vector_builder();
+    builder = builder_type();
 }
 
 } // end namespace

--- a/test/bit_vector_test.cpp
+++ b/test/bit_vector_test.cpp
@@ -38,7 +38,8 @@ rrr_vector<127>,
 rrr_vector<128>,
 sd_vector<>,
 sd_vector<rrr_vector<63> >,
-hyb_vector<>
+hyb_vector<>,
+rle_vector<>
 > Implementations;
 
 typedef Types<

--- a/test/rle_vector_test.cpp
+++ b/test/rle_vector_test.cpp
@@ -98,6 +98,7 @@ TYPED_TEST(rle_vector_test, from_builder)
 
     ASSERT_EQ(rlv.size(), BV_SIZE);
     ASSERT_EQ(rlv.ones(), ones);
+    ASSERT_EQ(rlv.runs(), runs.size());
     for (size_t i = 0; i < bv.size(); i++) {
         ASSERT_EQ((bool)rlv[i], (bool)bv[i]);
     }

--- a/test/rle_vector_test.cpp
+++ b/test/rle_vector_test.cpp
@@ -1,0 +1,115 @@
+#include "sdsl/rle_vector.hpp"
+#include "sdsl/bit_vectors.hpp"
+#include "gtest/gtest.h"
+
+using namespace sdsl;
+using namespace std;
+
+namespace
+{
+
+const size_t BV_SIZE = 1000000;
+
+std::vector<std::pair<uint64_t, uint64_t>>
+generate_runs(size_t size, size_t inverse_flip_probability)
+{
+    std::mt19937_64 rng;
+    std::uniform_int_distribution<uint64_t> distribution(0, inverse_flip_probability);
+    auto dice = bind(distribution, rng);
+
+    std::pair<uint64_t, uint64_t> run(0, 0);
+    bool ones = false;
+    std::vector<std::pair<uint64_t, uint64_t>> result;
+    for (size_t i = 0; i < size; ++i) {
+        if (ones) {
+            if (dice() == 0) {
+                result.push_back(run);
+                ones = false;
+            } else {
+                run.second++;
+            }
+        } else {
+            if (dice() == 0) {
+                run.first = i; run.second = 1;
+                ones = true;
+            }
+        }
+    }
+    if (ones) {
+        result.push_back(run);
+    }
+
+    return result;
+}
+
+size_t count_ones(const std::vector<std::pair<uint64_t, uint64_t>>& runs)
+{
+    size_t result = 0;
+    for (auto run : runs) { result += run.second; }
+    return result;
+}
+
+bit_vector
+mark_runs(const std::vector<std::pair<uint64_t, uint64_t>>& runs, size_t size)
+{
+    bit_vector result(size);
+    for (auto run : runs) {
+        for (uint64_t i = run.first; i < run.first + run.second; i++) {
+            result[i] = 1;
+        }
+    }
+    return result;
+}
+
+template<class T>
+class rle_vector_test : public ::testing::Test { };
+
+using testing::Types;
+
+typedef Types< rle_vector<64>, rle_vector<128> > Implementations;
+
+TYPED_TEST_CASE(rle_vector_test, Implementations);
+
+TYPED_TEST(rle_vector_test, from_bit_vector)
+{
+    std::vector<std::pair<uint64_t, uint64_t>> runs = generate_runs(BV_SIZE, 9);
+    bit_vector bv = mark_runs(runs, BV_SIZE);
+    size_t ones = count_ones(runs);
+    TypeParam rlv = bv;
+
+    ASSERT_EQ(rlv.size(), BV_SIZE);
+    ASSERT_EQ(rlv.ones(), ones);
+    for (size_t i = 0; i < bv.size(); i++) {
+        ASSERT_EQ((bool)rlv[i], (bool)bv[i]);
+    }
+}
+
+TYPED_TEST(rle_vector_test, from_builder)
+{
+    std::vector<std::pair<uint64_t, uint64_t>> runs = generate_runs(BV_SIZE, 9);
+    bit_vector bv = mark_runs(runs, BV_SIZE);
+    size_t ones = count_ones(runs);
+
+    typename TypeParam::builder_type builder(BV_SIZE);
+    for (auto run : runs) {
+        builder.set(run.first, run.second);
+    }
+    TypeParam rlv(builder);
+
+    ASSERT_EQ(rlv.size(), BV_SIZE);
+    ASSERT_EQ(rlv.ones(), ones);
+    for (size_t i = 0; i < bv.size(); i++) {
+        ASSERT_EQ((bool)rlv[i], (bool)bv[i]);
+    }
+}
+
+// FIXME construction with builder
+
+} // end namespace
+
+int main(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/test/rle_vector_test.cpp
+++ b/test/rle_vector_test.cpp
@@ -103,7 +103,20 @@ TYPED_TEST(rle_vector_test, from_builder)
     }
 }
 
-// FIXME construction with builder
+TYPED_TEST(rle_vector_test, builder_exceptions)
+{
+    {
+        // Position is too small.
+        typename TypeParam::builder_type builder(1024);
+        builder.set(128);
+        ASSERT_THROW(builder.set(128), std::runtime_error);
+    }
+    {
+        // Position is too large.
+        typename TypeParam::builder_type builder(1024);
+        ASSERT_THROW(builder.set(1024), std::runtime_error);
+    }
+}
 
 } // end namespace
 


### PR DESCRIPTION
This PR adds `rle_vector`, which is a run-length encoded bitvector similar to the one in the [RLCSA](https://jltsiren.kapsi.fi/rlcsa). The bitvector is encoded as an alternating sequence of run lengths of 0s and 1s, using 4-bit encoding. Each element contains 3 bits of data and a bit indicating whether the encoding continues. The encoding is divided into fixed-size blocks (default 64 elements), and `sd_vector`s store the number of bits and 1s before each block.

`rle_vector` currently supports the basic bitvector functionality: access, rank1, rank0, and select1. More operations may be added in the future.