### PR TITLE
Fix rle_vector

### DIFF
--- a/include/sdsl/rle_vector.hpp
+++ b/include/sdsl/rle_vector.hpp
@@ -562,7 +562,7 @@ class rank_support_rle
          */
         size_type rank(size_type i) const
         {
-            if (i >= this->parent->size()) { return this->parent->ones(); }
+            if (i >= this->parent->size()) { return rank_support_rle_trait<t_b>::adjust_rank(this->parent->ones(), this->parent->size()); }
 
             auto sample = *(this->parent->block_bits.predecessor(i));
             size_type body_offset = sample.first * t_block_size;
@@ -629,7 +629,7 @@ class select_support_rle
         size_type select(size_type i) const
         {
             if (i == 0) { return static_cast<size_type>(-1); }
-            if (i >= this->parent->ones()) { return this->parent->size(); }
+            if (i > this->parent->ones()) { return this->parent->size(); }
 
             auto sample = *(this->parent->block_ones.predecessor(i - 1)); // select(i) corresponds to block_ones[i - 1].
             size_type body_offset = sample.first * t_block_size;

--- a/include/sdsl/rle_vector.hpp
+++ b/include/sdsl/rle_vector.hpp
@@ -550,10 +550,12 @@ template<uint8_t t_b, uint64_t t_block_size>
 class rank_support_rle
 {
     public:
-        typedef rle_vector<t_block_size> vector_type;
-        typedef typename vector_type::size_type size_type;
+        typedef rle_vector<t_block_size> bit_vector_type;
+        typedef typename bit_vector_type::size_type size_type;
+        enum { bit_pat = t_b };
+        enum { bit_pat_len = (uint8_t)1 };
 
-        explicit rank_support_rle(const vector_type* v = nullptr) : parent(v) {}
+        explicit rank_support_rle(const bit_vector_type* v = nullptr) : parent(v) {}
 
         //! Returns the number of bits of type t_b before position i.
         /*!
@@ -579,12 +581,12 @@ class rank_support_rle
                 }
             }
 
-            return rank_support_rle_trait<t_b>::adjust_rank(result, this->parent->size());
+            return rank_support_rle_trait<t_b>::adjust_rank(result, i);
         }
 
         size_type operator()(size_type i) const { return this->rank(i); }
 
-        void set_vector(const vector_type* v = nullptr) { this->parent = v; }
+        void set_vector(const bit_vector_type* v = nullptr) { this->parent = v; }
 
         rank_support_rle& operator=(const rank_support_rle& another)
         {
@@ -594,7 +596,7 @@ class rank_support_rle
 
         void swap(rank_support_rle& another) { std::swap(this->parent, another.parent); }
 
-        void load(std::istream&, const vector_type* v = nullptr) { this->set_vector(v); }
+        void load(std::istream&, const bit_vector_type* v = nullptr) { this->set_vector(v); }
 
         size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
         {
@@ -603,7 +605,7 @@ class rank_support_rle
 
     private:
         static_assert(t_b == 1u or t_b == 0u , "rank_support_rle: bit pattern must be `0` or `1`");
-        const vector_type* parent;
+        const bit_vector_type* parent;
 };
 
 //-----------------------------------------------------------------------------
@@ -616,10 +618,12 @@ template<uint64_t t_block_size>
 class select_support_rle
 {
     public:
-        typedef rle_vector<t_block_size> vector_type;
-        typedef typename vector_type::size_type size_type;
+        typedef rle_vector<t_block_size> bit_vector_type;
+        typedef typename bit_vector_type::size_type size_type;
+        enum { bit_pat = (uint8_t)1 };
+        enum { bit_pat_len = (uint8_t)1 };
 
-        explicit select_support_rle(const vector_type* v = nullptr) : parent(v) {}
+        explicit select_support_rle(const bit_vector_type* v = nullptr) : parent(v) {}
 
         //! Returns the position of the i-th one in the bitvector.
         /*!
@@ -639,15 +643,15 @@ class select_support_rle
                 bv_offset += this->parent->run_of_zeros(body_offset);
                 size_type one_run = this->parent->run_of_ones(body_offset);
                 bv_offset += one_run; rank += one_run;
-                if (rank > i) {
-                    return bv_offset - (rank - 1 - i);
+                if (rank >= i) {
+                    return bv_offset - 1 - (rank - i);
                 }
             }
         }
 
         size_type operator()(size_type i) const { return this->select(i); }
 
-        void set_vector(const vector_type* v = nullptr) { this->parent = v; }
+        void set_vector(const bit_vector_type* v = nullptr) { this->parent = v; }
 
         select_support_rle& operator=(const select_support_rle& another)
         {
@@ -657,7 +661,7 @@ class select_support_rle
 
         void swap(select_support_rle& another) { std::swap(this->parent, another.parent); }
 
-        void load(std::istream&, const vector_type* v = nullptr) { this->set_vector(v); }
+        void load(std::istream&, const bit_vector_type* v = nullptr) { this->set_vector(v); }
 
         size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
         {
@@ -665,7 +669,7 @@ class select_support_rle
         }
 
     private:
-        const vector_type* parent;
+        const bit_vector_type* parent;
 };
 
 //-----------------------------------------------------------------------------

--- a/test/rank_support_test.cpp
+++ b/test/rank_support_test.cpp
@@ -61,7 +61,9 @@ typedef Types<rank_support_il<1, 256>,
         rank_support_v5<10,2>,
         rank_support_v5<01,2>,
         rank_support_v5<00,2>,
-        rank_support_v5<11,2>
+        rank_support_v5<11,2>,
+        rank_support_rle<1>,
+        rank_support_rle<0>
         > Implementations;
 
 TYPED_TEST_CASE(rank_support_test, Implementations);

--- a/test/rle_vector_test.cpp
+++ b/test/rle_vector_test.cpp
@@ -104,6 +104,26 @@ TYPED_TEST(rle_vector_test, from_builder)
     }
 }
 
+TYPED_TEST(rle_vector_test, special_cases)
+{
+    std::vector<std::pair<uint64_t, uint64_t>> runs = generate_runs(BV_SIZE, 9);
+    typename TypeParam::builder_type builder(BV_SIZE);
+    for (auto run : runs) {
+        builder.set(run.first, run.second);
+    }
+    TypeParam rlv(builder);
+
+    typename TypeParam::rank_1_type rs_1(&rlv);
+    ASSERT_EQ(rs_1(rlv.size()), rlv.ones());
+
+    typename TypeParam::rank_0_type rs_0(&rlv);
+    ASSERT_EQ(rs_0(rlv.size()), rlv.size() - rlv.ones());
+
+    typename TypeParam::select_1_type ss(&rlv);
+    ASSERT_EQ(ss(0), static_cast<typename TypeParam::size_type>(-1));
+    ASSERT_EQ(ss(rlv.ones() + 1), rlv.size());
+}
+
 TYPED_TEST(rle_vector_test, builder_exceptions)
 {
     {

--- a/test/sd_vector_test.cpp
+++ b/test/sd_vector_test.cpp
@@ -82,6 +82,11 @@ TYPED_TEST(sd_vector_test, one_iterator)
     }
     TypeParam sdv(builder);
 
+    // At end.
+    auto iter = sdv.one_end();
+    ASSERT_EQ(iter->first, sdv.ones());
+    ASSERT_EQ(iter->second, sdv.size());
+
     // Iterate forward.
     size_t expected = 0;
     for (auto iter = sdv.one_begin(); iter != sdv.one_end(); ++iter) {

--- a/test/sd_vector_test.cpp
+++ b/test/sd_vector_test.cpp
@@ -83,9 +83,11 @@ TYPED_TEST(sd_vector_test, one_iterator)
     TypeParam sdv(builder);
 
     // At end.
-    auto iter = sdv.one_end();
-    ASSERT_EQ(iter->first, sdv.ones());
-    ASSERT_EQ(iter->second, sdv.size());
+    {
+        auto iter = sdv.one_end();
+        ASSERT_EQ(iter->first, sdv.ones());
+        ASSERT_EQ(iter->second, sdv.size());
+    }
 
     // Iterate forward.
     size_t expected = 0;

--- a/test/select_support_test.cpp
+++ b/test/select_support_test.cpp
@@ -45,7 +45,8 @@ typedef Types<select_support_mcl<>,
         select_support_mcl<01,2>,
         select_support_mcl<10,2>,
         select_support_mcl<00,2>,
-        select_support_mcl<11,2>
+        select_support_mcl<11,2>,
+        select_support_rle<>
         > Implementations;
 
 TYPED_TEST_CASE(select_support_test, Implementations);


### PR DESCRIPTION
Rank/select tests are apparently separate from bitvector tests. This PR adds `rle_vector` to the rank/select tests and fixes some trivial bugs.