### PR TITLE
Simple-SDS serialization format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ As [SDSL 2](https://github.com/simongog/sdsl-lite) is no longer maintained, vgte
   * Defined semantics for an `sd_vector` encoding a multiset of integers.
 * `rle_vector`: A run-length encoded bitvector.
 * Proper support for 64-bit ARM.
+* Support for the [simple-sds serialization format](https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md):
+  * `int_vector<0>` corresponds to `IntegerVector`.
+  * `int_vector<1>` corresponds to `BitVector`.
+  * `int_vector<8>` and `int_vector<64>` correspond to vectors of bytes and elements.
+  * `sd_vector<>` corresponds to `SparseVector`.
 
 ## Tools/libraries using this fork
 

--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -501,12 +501,12 @@ class int_vector
          *  This corresponds to several different simple-sds structures, depending on `t_width`.
          *  `0`: integer vector, `1`: bitvector, other: vector.
          */
-        void simple_sds_load(std::istream& in); // FIXME implement
+        void simple_sds_load(std::istream& in);
 
         //! Returns the size of the vector in elements.
         /*! \return Number of elements required for serializing the vector.
          */
-        size_t simple_sds_size() const; // FIXME implement
+        size_t simple_sds_size() const;
 
         //! non const version of [] operator
         /*! \param i Index the i-th integer of length width().

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -449,12 +449,18 @@ class sd_vector
                 double ideal_width = std::log2((static_cast<double>(universe) * std::log(2.0)) / static_cast<double>(ones));
                 low_width = std::round(std::max(ideal_width, 1.0));
             }
+            size_type buckets = get_buckets(universe, low_width);
+            return std::pair<size_type, size_type>(low_width, ones + buckets);
+        }
 
+        // Returns the number of buckets.
+        static size_type get_buckets(size_type universe, size_type low_width)
+        {
             size_type buckets = universe >> low_width;
             if ((universe & bits::lo_set[low_width]) != 0) {
                 buckets++;
             }
-            return std::pair<size_type, size_type>(low_width, ones + buckets);
+            return buckets;
         }
 
 //-----------------------------------------------------------------------------
@@ -631,6 +637,37 @@ class sd_vector
 
 //-----------------------------------------------------------------------------
 
+        //! Serializes the vector to a stream in the simple-sds format.
+        /*! \param out The output stream.
+         *
+         *  \par Error handling is based on exceptions from the output stream.
+         *  This corresponds to a simple-sds sparse bitvector.
+         *  NOTE: simple-sds serialization has only been implemented for the default template parameters.
+         */
+        void simple_sds_serialize(std::ostream& out) const {
+            throw std::logic_error("simple-sds serialization has not been implemented for these template parameters");
+        }
+
+        //! Loads the vector to a stream in the simple-sds format.
+        /*! \param in The input stream.
+         *
+         *  \par Error handling is based on exceptions from the input stream.
+         *  This corresponds to a simple-sds sparse bitvector.
+         *  NOTE: simple-sds serialization has only been implemented for the default template parameters.
+         */
+        void simple_sds_load(std::istream& in) {
+            throw std::logic_error("simple-sds serialization has not been implemented for these template parameters");
+        }
+
+        //! Returns the size of the vector in elements.
+        /*! \return Number of elements required for serializing the vector.
+         */
+        size_t simple_sds_size() const {
+            throw std::logic_error("simple-sds serialization has not been implemented for these template parameters");
+        }
+
+//-----------------------------------------------------------------------------
+
         iterator begin() const
         {
             return iterator(this, 0);
@@ -751,6 +788,15 @@ class sd_vector
 
 //! Specialized constructor that is a bit more space-efficient than the default.
 template<> sd_vector<>::sd_vector(builder_type& builder);
+
+//! simple-sds serialization for the default template parameters.
+template<> void sd_vector<>::simple_sds_serialize(std::ostream& out) const;
+
+//! simple-sds loading for the default template parameters.
+template<> void sd_vector<>::simple_sds_load(std::istream& in);
+
+//! simple-sds serialized size for the default template parameters.
+template<> size_t sd_vector<>::simple_sds_size() const;
 
 //-----------------------------------------------------------------------------
 

--- a/include/sdsl/simple_sds.hpp
+++ b/include/sdsl/simple_sds.hpp
@@ -1,0 +1,264 @@
+/* sdsl - succinct data structures library
+    Copyright (C) 2021 Jouni Sirén
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/ .
+*/
+/*! \file simple_sds.hpp
+    \brief simple_sds.hpp implements the basics of the simple-sds serialization format.
+	\author Jouni Sirén
+*/
+
+#ifndef INCLUDED_SDSL_SIMPLE_SDS
+#define INCLUDED_SDSL_SIMPLE_SDS
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+//! Namespace for SDSL.
+namespace sdsl
+{
+
+//! Namespace for the simple-sds serialization format.
+/*! \par The simple-sds serialization format is defined in
+ *  https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md.
+ *  This namespace implements serializing and loading basic types:
+ *  serializable types, vectors, and optional structures.
+ *
+ *  \par Error handling is based on exceptions. Any exceptions from the input
+ *  and output streams are passed through. Implementations may use the
+ *  provided `InvalidData` exception to indicate that the loaded data failed
+ *  sanity checks.
+ *
+ *  \par The serialization format is based on elements, which are unsigned
+ *  64-bit little-endian integers. Any structure that implements the
+ *  serialization interface can be serialized:
+ *
+ *  - `void simple_sds_serialize(std::ofstream&) const`: Serialize the structure
+ *  into the stream.
+ *  - `static Structure` simple_sds_load(std::ifstream&)`: Load the structure
+ *  from the stream.
+ *  - `size_t simple_sds_size() const`: Number of elements needed for
+ *  serializing the structure.
+ */
+namespace simple_sds
+{
+
+//-----------------------------------------------------------------------------
+
+//! Serialization is defined in terms of unsigned 64-bit little-endian integers.
+typedef std::uint64_t element_type;
+
+//! Custom exception type that extends `std::runtime_error`.
+/*! \par This exception indicates that the loaded data failed sanity checks
+ */
+class InvalidData : public std::runtime_error {
+    //! Constructor.
+    /*! \param message Message returned by the `what()` method.
+     */
+    explicit InvalidData(const std::string& message) : std::runtime_error(message) {}
+};
+
+//! Serialize the data in a buffer.
+/*! \param buffer A non-null pointer to the buffer.
+ *  \param size Size of the buffer in bytes.
+ *  \param out Output stream for serialization.
+ *
+ *  \par The buffer will be serialized in 32 MiB blocks.
+ */
+void serialize_data(const char* buffer, size_t size, std::ostream& out);
+
+//! Load data into a buffer.
+/*! \param buffer A non-null pointer to the buffer.
+ *  \param size Size of the buffer in bytes.
+ *  \param out Input stream for loading the data.
+ *
+ *  \par The buffer will be loaded in 32 MiB blocks.
+ */
+void load_data(char* buffer, size_t size, std::istream& in);
+
+//-----------------------------------------------------------------------------
+
+//! Serialize a serializable value.
+/*! \tparam Serializable A fixed-size type with the size a multiple of 8 bytes.
+ *  \param value Value to be serialized.
+ *  \param out Output stream for serialization.
+ *
+ *  \par This corresponds to a serializable type in simple-sds.
+ */
+template<typename Serializable>
+void serialize_value(const Serializable& value, std::ostream& out) {
+    static_assert(sizeof(Serializable) % sizeof(element_type) == 0, "The size of a serializable type must be a multiple of 8 bytes");
+    out.write(reinterpret_cast<const char*>(&value), sizeof(value));
+}
+
+//! Load a serializable value.
+/*! \tparam Serializable A fixed-size type with the size a multiple of 8 bytes.
+ *  \param int Input stream for loading the data.
+ *  \return The loaded value.
+ *
+ *  \par This corresponds to a serializable type in simple-sds.
+ */
+template <typename Serializable>
+Serializable load_value(std::istream& in) {
+    static_assert(sizeof(Serializable) % sizeof(element_type) == 0, "The size of a serializable type must be a multiple of 8 bytes");
+    Serializable value;
+    in.read(reinterpret_cast<char*>(&value), sizeof(value));
+    return value;
+}
+
+//! Serialize a vector of items.
+/*! \tparam Item A fixed-size type with the size either 1 byte or a multiple of 8 bytes.
+ *  \param value The vector to be serialized.
+ *  \param out Output stream for serialization.
+ *
+ *  \par This corresponds to a vector of serializable items or bytes in simple-sds.
+ */
+template<typename Item>
+void serialize_vector(const std::vector<Item>& value, std::ostream& out) {
+    static_assert(sizeof(Item) == 1 || sizeof(Item) % sizeof(element_type) == 0, "The size of an item must be 1 byte or a multiple of 8 bytes");
+    serialize_value(value.size(), out);
+    serialize_data(reinterpret_cast<const char*>(value.data()), value.size() * sizeof(Item), out);
+}
+
+//! Load a vector of items.
+/*! \tparam Item A fixed-size type with the size either 1 byte or a multiple of 8 bytes.
+ *  \param int Input stream for loading the data.
+ *  \return The loaded vector.
+ *
+ *  \par This corresponds to a vector of serializable items or bytes in simple-sds.
+ */
+template<typename Item>
+std::vector<Item> load_vector(std::istream& in) {
+    static_assert(sizeof(Item) == 1 || sizeof(Item) % sizeof(element_type) == 0, "The size of an item must be 1 byte or a multiple of 8 bytes");
+    std::vector<Item> result(load_value<size_t>(in));
+    load_data(reinterpret_cast<char*>(result.data()), result.size() * sizeof(Item), in);
+    return result;
+}
+
+//! Serialize a string.
+/*! \param value The string to be serialized.
+ *  \param out Output stream for serialization.
+ *
+ *  \par This corresponds to a string in simple-sds.
+ */
+void serialize_string(const std::string& value, std::ostream& out);
+
+//! Load a string.
+/*! \param int Input stream for loading the data.
+ *  \return The loaded string.
+ *
+ *  \par This corresponds to a string in simple-sds.
+ *  However, the method does not validate that the bytes encode a valid UTF-8 string.
+ */
+std::string load_string(std::istream& in);
+
+//! Serialize an empty optional structure.
+/*! \param out Output stream for serialization.
+ *
+ *  \par This corresponds to an absent optional structure in simple-sds.
+ */
+void empty_option(std::ostream& out);
+
+//! Serialize a non-empty optional structure.
+/*! \tparam Serialize A type implementing the serialization interface.
+ *  \param value The value to be serialized.
+ *  \param out Output stream for serialization.
+ *
+ *  \par This corresponds to a present optional structure in simple-sds.
+ */
+template<typename Serialize>
+void serialize_option(const Serialize& value, std::ostream& out) {
+    serialize_value(value.simple_sds_size(), out);
+    value.simple_sds_serialize(out);
+}
+
+//! Skip an optional structure without reading it.
+/*! \param in Input stream for loading the data.
+ */
+void skip_option(std::istream& in);
+
+//! Load an optional structure.
+/*! \tparam Item A fixed-size type with the size either 1 byte or a multiple of 8 bytes.
+ *  \param int Input stream for loading the data.
+ *  \return A pair where the first component contains the possible value and the second
+ *  component is `true` if the value is present and `false` if it is absent.
+ *
+ *  \par This corresponds to an optional structure in simple-sds.
+ *  The method throws `InvalidData` if the value is present but its size is invalid.
+ */
+template<typename Serialize>
+std::pair<Serialize, bool> load_option(std::istream& in) {
+    std::pair<Serialize, bool> result;
+    size_t size = load_value<size_t>(in);
+    std::streampos expected = in.tellg() + size * sizeof(element_type);
+    if (size == 0) {
+        result.second = false;
+    } else {
+        result.first.simple_sds_load(in);
+        if (in.tellg() != expected) {
+            throw InvalidData("Incorrect size for an optional structure");
+        }
+        result.second = true;
+    }
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+
+//! Serializes a structure into the given file.
+/*! \tparam Serialize A type implementing the serialization interface.
+ *  \param data The structure to be serialized.
+ *  \param filename File name for serialization.
+ *
+ *  \par If the file exists, it will be overwritten.
+ *  Output stream errors are thrown as exceptions.
+ *  Any exceptions from serialization methods will be passed through.
+ */
+template<typename Serialize>
+void serialize_to(const Serialize& data, const std::string& filename) {
+    std::ofstream out;
+    out.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+    out.open(filename, std::ios_base::binary);
+    data.simple_sds_serialize(out);
+    out.close();
+}
+
+//! Loads a structure from the given file.
+/*! \tparam Serialize A type implementing the serialization interface.
+ *  \param data The structure to be loaded.
+ *  \param filename File name for the data.
+ *
+ *  \par Input stream errors are thrown as exceptions.
+ *  Any exceptions from serialization methods will be passed through.
+ */
+template<typename Serialize>
+void load_from(Serialize& data, const std::string& filename) {
+    std::ifstream in;
+    in.exceptions(std::ifstream::eofbit | std::ifstream::badbit | std::ifstream::failbit);
+    in.open(filename, std::ios_base::binary);
+    data.simple_sds_load(in);
+    in.close();
+}
+
+//-----------------------------------------------------------------------------
+
+} // namespace simple_sds
+
+} // namespace sdsl
+
+#endif // INCLUDED_SDSL_SIMPLE_SDS

--- a/lib/simple_sds.cpp
+++ b/lib/simple_sds.cpp
@@ -48,6 +48,10 @@ void load_data(char* buffer, size_t size, std::istream& in) {
     }
 }
 
+size_t data_size(size_t bytes) {
+    return (bytes + padding_length(bytes)) / sizeof(element_type);
+}
+
 //-----------------------------------------------------------------------------
 
 void serialize_string(const std::string& value, std::ostream& out) {
@@ -63,7 +67,13 @@ std::string load_string(std::istream& in) {
     return result;
 }
 
-void missing_option(std::ostream& out) {
+size_t string_size(const std::string& value) {
+    return value_size(value.size()) + data_size(value.length());
+}
+
+//-----------------------------------------------------------------------------
+
+void empty_option(std::ostream& out) {
     size_t size = 0;
     serialize_value(size, out);
 }
@@ -71,6 +81,10 @@ void missing_option(std::ostream& out) {
 void skip_option(std::istream& in) {
     size_t size = load_value<size_t>(in);
     in.seekg(size * sizeof(element_type), std::ios_base::cur);
+}
+
+size_t empty_option_size() {
+    return value_size<size_t>();
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/simple_sds.cpp
+++ b/lib/simple_sds.cpp
@@ -18,12 +18,14 @@ constexpr size_t BLOCK_SIZE = 32 * 1048576;
 //-----------------------------------------------------------------------------
 
 // Returns the number of bytes of padding required after `bytes` bytes of data.
-size_t padding_length(size_t bytes) {
+size_t padding_length(size_t bytes)
+{
     size_t overflow = bytes & (sizeof(element_type) - 1);
     return (overflow > 0 ? sizeof(element_type) - overflow : 0);
 }
 
-void serialize_data(const char* buffer, size_t size, std::ostream& out) {
+void serialize_data(const char* buffer, size_t size, std::ostream& out)
+{
     for (size_t i = 0; i < size; i += BLOCK_SIZE) {
         size_t length = std::min(BLOCK_SIZE, size - i);
         out.write(buffer + i, length);
@@ -36,7 +38,8 @@ void serialize_data(const char* buffer, size_t size, std::ostream& out) {
     }
 }
 
-void load_data(char* buffer, size_t size, std::istream& in) {
+void load_data(char* buffer, size_t size, std::istream& in)
+{
     for (size_t i = 0; i < size; i += BLOCK_SIZE) {
         size_t length = std::min(BLOCK_SIZE, size - i);
         in.read(buffer + i, length);
@@ -54,12 +57,14 @@ size_t data_size(size_t bytes) {
 
 //-----------------------------------------------------------------------------
 
-void serialize_string(const std::string& value, std::ostream& out) {
+void serialize_string(const std::string& value, std::ostream& out)
+{
     serialize_value(value.length(), out);
     serialize_data(value.data(), value.length(), out);
 }
 
-std::string load_string(std::istream& in) {
+std::string load_string(std::istream& in)
+{
     std::string result(load_value<size_t>(in), '\0');
     if (result.length() > 0) {
         load_data(&(result.front()), result.length(), in);
@@ -67,23 +72,27 @@ std::string load_string(std::istream& in) {
     return result;
 }
 
-size_t string_size(const std::string& value) {
+size_t string_size(const std::string& value)
+{
     return value_size(value.size()) + data_size(value.length());
 }
 
 //-----------------------------------------------------------------------------
 
-void empty_option(std::ostream& out) {
+void empty_option(std::ostream& out)
+{
     size_t size = 0;
     serialize_value(size, out);
 }
 
-void skip_option(std::istream& in) {
+void skip_option(std::istream& in)
+{
     size_t size = load_value<size_t>(in);
     in.seekg(size * sizeof(element_type), std::ios_base::cur);
 }
 
-size_t empty_option_size() {
+size_t empty_option_size()
+{
     return value_size<size_t>();
 }
 

--- a/lib/simple_sds.cpp
+++ b/lib/simple_sds.cpp
@@ -1,0 +1,80 @@
+#include "sdsl/simple_sds.hpp"
+
+#include <algorithm>
+
+//! Namespace for SDSL.
+namespace sdsl
+{
+
+//! Namespace for the Simple-SDS serialization format.
+namespace simple_sds
+{
+
+//-----------------------------------------------------------------------------
+
+// Vectors are serialized in blocks of 32 MiB.
+constexpr size_t BLOCK_SIZE = 32 * 1048576;
+
+//-----------------------------------------------------------------------------
+
+// Returns the number of bytes of padding required after `bytes` bytes of data.
+size_t padding_length(size_t bytes) {
+    size_t overflow = bytes & (sizeof(element_type) - 1);
+    return (overflow > 0 ? sizeof(element_type) - overflow : 0);
+}
+
+void serialize_data(const char* buffer, size_t size, std::ostream& out) {
+    for (size_t i = 0; i < size; i += BLOCK_SIZE) {
+        size_t length = std::min(BLOCK_SIZE, size - i);
+        out.write(buffer + i, length);
+    }
+
+    size_t padding = padding_length(size);
+    if (padding > 0) {
+        size_t zero = 0;
+        out.write(reinterpret_cast<const char*>(&zero), padding);
+    }
+}
+
+void load_data(char* buffer, size_t size, std::istream& in) {
+    for (size_t i = 0; i < size; i += BLOCK_SIZE) {
+        size_t length = std::min(BLOCK_SIZE, size - i);
+        in.read(buffer + i, length);
+    }
+
+    size_t padding = padding_length(size);
+    if (padding > 0) {
+        in.seekg(padding, std::ios_base::cur);
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+void serialize_string(const std::string& value, std::ostream& out) {
+    serialize_value(value.length(), out);
+    serialize_data(value.data(), value.length(), out);
+}
+
+std::string load_string(std::istream& in) {
+    std::string result(load_value<size_t>(in), '\0');
+    if (result.length() > 0) {
+        load_data(&(result.front()), result.length(), in);
+    }
+    return result;
+}
+
+void missing_option(std::ostream& out) {
+    size_t size = 0;
+    serialize_value(size, out);
+}
+
+void skip_option(std::istream& in) {
+    size_t size = load_value<size_t>(in);
+    in.seekg(size * sizeof(element_type), std::ios_base::cur);
+}
+
+//-----------------------------------------------------------------------------
+
+} // namespace simple_sds
+
+} // namespace sdsl

--- a/test/simple_sds_test.cpp
+++ b/test/simple_sds_test.cpp
@@ -1,0 +1,194 @@
+#include "sdsl/simple_sds.hpp"
+#include "gtest/gtest.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace sdsl::simple_sds;
+
+namespace
+{
+
+//-----------------------------------------------------------------------------
+
+struct ByteArray
+{
+    std::vector<std::uint8_t> bytes;
+    size_t                    sum = 0;
+
+    void simple_sds_serialize(std::ostream& out) const {
+        serialize_vector(this->bytes, out);
+        serialize_value(this->sum, out);
+    }
+
+    void simple_sds_load(std::istream& in) {
+        this->bytes = load_vector<std::uint8_t>(in);
+        this->sum = load_value<size_t>(in);
+        size_t real_sum = 0;
+        for (auto value : this->bytes) { real_sum += value; }
+        if (real_sum != this->sum) {
+            throw InvalidData("Incorrect sum");
+        }
+    }
+
+    size_t simple_sds_size() const {
+        return vector_size(this->bytes) + value_size(this->sum);
+    }
+
+    bool operator==(const ByteArray& another) const {
+        return (this->bytes == another.bytes && this->sum == another.sum);
+    }
+};
+
+struct ComplexStructure
+{
+    std::pair<size_t, size_t> header;
+    bool                      has_byte_array;
+    ByteArray                 byte_array;
+    std::vector<double>       numbers;
+
+    void simple_sds_serialize(std::ostream& out) const {
+        serialize_value(this->header, out);
+        if (this->has_byte_array) {
+            serialize_option(this->byte_array, out);
+        } else {
+            empty_option(out);
+        }
+        serialize_vector(this->numbers, out);
+    }
+
+    void simple_sds_load(std::istream& in) {
+        this->header = load_value<std::pair<size_t, size_t>>(in);
+        this->has_byte_array = load_option(this->byte_array, in);
+        this->numbers = load_vector<double>(in);
+    }
+
+    size_t simple_sds_size() const {
+        size_t result = value_size(this->header);
+        result += (this->has_byte_array ? option_size(this->byte_array) : empty_option_size());
+        result += vector_size(this->numbers);
+        return result;
+    }
+
+    bool operator==(const ComplexStructure& another) const {
+        return (this->header == another.header &&
+                this->has_byte_array == another.has_byte_array &&
+                this->byte_array == another.byte_array &&
+                this->numbers == another.numbers);
+    }
+};
+
+//-----------------------------------------------------------------------------
+
+void check_complex_structure(const ComplexStructure& original, size_t expected_size) {
+    ASSERT_EQ(original.simple_sds_size(), expected_size) << "Invalid serialization size in elements";
+
+    char buffer[] = "simple-sds-XXXXXX";
+    int fail = mkstemp(buffer);
+    ASSERT_NE(fail, -1) << "Temporary file creation failed";
+    std::string filename(buffer);
+
+    serialize_to(original, filename);
+    size_t file_size = 0;
+    struct stat stat_buf;
+    if (stat(filename.c_str(), &stat_buf) == 0) { file_size = stat_buf.st_size; }
+    EXPECT_EQ(file_size, expected_size * sizeof(element_type)) << "Invalid file size";
+
+    ComplexStructure loaded;
+    load_from(loaded, filename);
+    EXPECT_EQ(loaded, original) << "Invalid loaded structure";
+
+    std::ifstream in(filename, std::ios_base::binary);
+    in.seekg(value_size(original.header) * sizeof(element_type));
+    skip_option(in);
+    std::vector<double> numbers = load_vector<double>(in);
+    EXPECT_EQ(numbers, original.numbers) << "Invalid numbers after skipping the optional structure";
+
+    std::remove(filename.c_str());
+}
+
+//-----------------------------------------------------------------------------
+
+TEST(SimpleSDSTest, Empty)
+{
+    ComplexStructure original = {
+        { 123, 456, },
+        false,
+        { { }, 0, },
+        { },
+    };
+    size_t expected_size = 2 + 1 + 1;
+    check_complex_structure(original, expected_size);
+}
+
+TEST(SimpleSDSTest, Numbers)
+{
+    ComplexStructure original = {
+        { 123, 456, },
+        false,
+        { { }, 0, },
+        { 1.0, 2.0, 3.0, 5.0, },
+    };
+    size_t expected_size = 2 + 1 + 5;
+    check_complex_structure(original, expected_size);
+}
+
+TEST(SimpleSDSTest, EmptyBytes)
+{
+    ComplexStructure original = {
+        { 123, 456, },
+        true,
+        { { }, 0, },
+        { },
+    };
+    size_t expected_size = 2 + 3 + 1;
+    check_complex_structure(original, expected_size);
+}
+
+TEST(SimpleSDSTest, BytesWithPadding)
+{
+    ComplexStructure original = {
+        { 123, 456, },
+        true,
+        { { 1, 2, 3, 5, 8, }, 19, },
+        { },
+    };
+    size_t expected_size = 2 + 4 + 1;
+    check_complex_structure(original, expected_size);
+}
+
+TEST(SimpleSDSTest, BytesAndNumbers)
+{
+    ComplexStructure original = {
+        { 123, 456, },
+        true,
+        { { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, }, 136, },
+        { 1.0, 2.0, 3.0, 5.0 },
+    };
+    size_t expected_size = 2 + 5 + 5;
+    check_complex_structure(original, expected_size);
+}
+
+TEST(SimpleSDSTest, BytesAndNumbersWithPadding)
+{
+    ComplexStructure original = {
+        { 123, 456, },
+        true,
+        { { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, }, 120, },
+        { 1.0, 2.0, 3.0, 5.0 },
+    };
+    size_t expected_size = 2 + 5 + 5;
+    check_complex_structure(original, expected_size);
+}
+
+//-----------------------------------------------------------------------------
+
+} // anonymous namespace
+
+int main(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+//-----------------------------------------------------------------------------

--- a/test/simple_sds_test.cpp
+++ b/test/simple_sds_test.cpp
@@ -16,12 +16,14 @@ struct ByteArray
     std::vector<std::uint8_t> bytes;
     size_t                    sum = 0;
 
-    void simple_sds_serialize(std::ostream& out) const {
+    void simple_sds_serialize(std::ostream& out) const
+    {
         serialize_vector(this->bytes, out);
         serialize_value(this->sum, out);
     }
 
-    void simple_sds_load(std::istream& in) {
+    void simple_sds_load(std::istream& in)
+    {
         this->bytes = load_vector<std::uint8_t>(in);
         this->sum = load_value<size_t>(in);
         size_t real_sum = 0;
@@ -31,11 +33,13 @@ struct ByteArray
         }
     }
 
-    size_t simple_sds_size() const {
+    size_t simple_sds_size() const
+    {
         return vector_size(this->bytes) + value_size(this->sum);
     }
 
-    bool operator==(const ByteArray& another) const {
+    bool operator==(const ByteArray& another) const
+    {
         return (this->bytes == another.bytes && this->sum == another.sum);
     }
 };
@@ -47,7 +51,8 @@ struct ComplexStructure
     ByteArray                 byte_array;
     std::vector<double>       numbers;
 
-    void simple_sds_serialize(std::ostream& out) const {
+    void simple_sds_serialize(std::ostream& out) const
+    {
         serialize_value(this->header, out);
         if (this->has_byte_array) {
             serialize_option(this->byte_array, out);
@@ -57,20 +62,23 @@ struct ComplexStructure
         serialize_vector(this->numbers, out);
     }
 
-    void simple_sds_load(std::istream& in) {
+    void simple_sds_load(std::istream& in)
+    {
         this->header = load_value<std::pair<size_t, size_t>>(in);
         this->has_byte_array = load_option(this->byte_array, in);
         this->numbers = load_vector<double>(in);
     }
 
-    size_t simple_sds_size() const {
+    size_t simple_sds_size() const
+    {
         size_t result = value_size(this->header);
         result += (this->has_byte_array ? option_size(this->byte_array) : empty_option_size());
         result += vector_size(this->numbers);
         return result;
     }
 
-    bool operator==(const ComplexStructure& another) const {
+    bool operator==(const ComplexStructure& another) const
+    {
         return (this->header == another.header &&
                 this->has_byte_array == another.has_byte_array &&
                 this->byte_array == another.byte_array &&
@@ -80,7 +88,8 @@ struct ComplexStructure
 
 //-----------------------------------------------------------------------------
 
-void check_complex_structure(const ComplexStructure& original, size_t expected_size) {
+void check_complex_structure(const ComplexStructure& original, size_t expected_size)
+{
     ASSERT_EQ(original.simple_sds_size(), expected_size) << "Invalid serialization size in elements";
 
     char buffer[] = "simple-sds-XXXXXX";

--- a/test/simple_sds_test.cpp
+++ b/test/simple_sds_test.cpp
@@ -323,21 +323,21 @@ public:
 TEST_F(BitVector, Empty)
 {
     bit_vector original;
-    size_t expected_size = 2 + 0 + 3;
+    size_t expected_size = 3 + 0 + 3;
     this->check(original, expected_size);
 }
 
 TEST_F(BitVector, WithPadding)
 {
     bit_vector original = random_bit_vector(515, 0.5);
-    size_t expected_size = 2 + 9 + 3;
+    size_t expected_size = 3 + 9 + 3;
     this->check(original, expected_size);
 }
 
 TEST_F(BitVector, NoPadding)
 {
     bit_vector original = random_bit_vector(448, 0.5);
-    size_t expected_size = 2 + 7 + 3;
+    size_t expected_size = 3 + 7 + 3;
     this->check(original, expected_size);
 }
 


### PR DESCRIPTION
Support for the [simple-sds serialization format](https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md):

* `int_vector<0>` corresponds to `IntegerVector`.
* `int_vector<1>` corresponds to `BitVector`.
* `int_vector<8>` and `int_vector<64>` correspond to vectors of bytes and elements.
* `sd_vector<>` corresponds to `SparseVector`.
