### PR TITLE
Simple-SDS improvements

### DIFF
--- a/include/sdsl/simple_sds.hpp
+++ b/include/sdsl/simple_sds.hpp
@@ -338,8 +338,15 @@ template<typename Serialize>
 void serialize_to(const Serialize& data, const std::string& filename)
 {
     std::ofstream out;
-    out.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+
+    // The default error message can be uninformative.
     out.open(filename, std::ios_base::binary);
+    if (!out) {
+        std::string msg = "serialize_to: Cannot open "; msg += filename;
+        throw std::ofstream::failure(msg);
+    }
+
+    out.exceptions(std::ofstream::failbit | std::ofstream::badbit);
     data.simple_sds_serialize(out);
     out.close();
 }
@@ -356,8 +363,15 @@ template<typename Serialize>
 void load_from(Serialize& data, const std::string& filename)
 {
     std::ifstream in;
-    in.exceptions(std::ifstream::eofbit | std::ifstream::badbit | std::ifstream::failbit);
+
+    // The default error message can be uninformative.
     in.open(filename, std::ios_base::binary);
+    if (!in) {
+        std::string msg = "load_from: Cannot open "; msg += filename;
+        throw std::ifstream::failure(msg);
+    }
+
+    in.exceptions(std::ifstream::eofbit | std::ifstream::badbit | std::ifstream::failbit);
     data.simple_sds_load(in);
     in.close();
 }

--- a/include/sdsl/simple_sds.hpp
+++ b/include/sdsl/simple_sds.hpp
@@ -355,10 +355,8 @@ size_t option_size(const Serialize& value)
 template<typename Serialize>
 void serialize_to(const Serialize& data, const std::string& filename)
 {
-    std::ofstream out;
-
     // The default error message can be uninformative.
-    out.open(filename, std::ios_base::binary);
+    std::ofstream out(filename, std::ios_base::binary);
     if (!out) {
         throw CannotOpenFile(filename, true);
     }
@@ -380,10 +378,8 @@ void serialize_to(const Serialize& data, const std::string& filename)
 template<typename Serialize>
 void load_from(Serialize& data, const std::string& filename)
 {
-    std::ifstream in;
-
     // The default error message can be uninformative.
-    in.open(filename, std::ios_base::binary);
+    std::ifstream in(filename, std::ios_base::binary);
     if (!in) {
         throw CannotOpenFile(filename, false);
     }


### PR DESCRIPTION
* Use the correct number of buckets in `sd_vector::simple_sds_serialize` if the vector is from an old SDSL version that creates too many buckets.
* Throw more informative exceptions from `simple_sds::serialize_to` and `simple_sds::load_from` if the file cannot be opened.