### PR TITLE
Exclude "gtest" from installing along with the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIBRARY_VERSION_FULL "${LIBRARY_VERSION}.${LIBRARY_VERSION_PATCH}")
 
 option(CODE_COVERAGE "Set ON to add code coverage compile options" OFF)
 option(GENERATE_DOC "Set ON to generate doxygen API reference in build/doc directory" OFF)
+option(WITH_GOOGLETEST "Set ON to install google test along with the library" ON)
 
 # C++14 compiler Check
 if(CMAKE_CXX_COMPILER MATCHES ".*clang.*" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -23,6 +23,8 @@ if(NOT EXISTS ${gtest_file})
             )
 endif(NOT EXISTS ${gtest_file})
 
+if(WITH_GOOGLETEST)
+add_subdirectory(googletest/googletest)
+else(WITH_GOOGLETEST)
 add_subdirectory(googletest/googletest EXCLUDE_FROM_ALL)
-
-
+endif(WITH_GOOGLETEST)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -23,6 +23,6 @@ if(NOT EXISTS ${gtest_file})
             )
 endif(NOT EXISTS ${gtest_file})
 
-add_subdirectory(googletest/googletest)
+add_subdirectory(googletest/googletest EXCLUDE_FROM_ALL)
 
 


### PR DESCRIPTION
This avoids clashing with the installed version of "googletest". I want to create a conda-forge recipe for this fork (`sdsl-lite-vgteam`) and this might create a conflict with "gtest" package.