### PR TITLE
Add conditional C++20 macros for result_of

### DIFF
--- a/include/sdsl/iterators.hpp
+++ b/include/sdsl/iterators.hpp
@@ -174,7 +174,12 @@ template<typename t_F>
 struct random_access_container {
     typedef int_vector<>::size_type                               size_type;
     typedef int_vector<>::difference_type                         difference_type;
+
+#if __cplusplus >= 202002L
+    typedef typename std::invoke_result<t_F, size_type>::type         value_type;
+#else
     typedef typename std::result_of<t_F(size_type)>::type         value_type;
+#endif
     typedef random_access_const_iterator<random_access_container> iterator_type;
 
     t_F f;


### PR DESCRIPTION
When compiling on a system that requires `result_of` to be deprecated (as of c++17), sdsl-lite fails. This simple macro (thanks to @adamnovak) fixes that