### PR TITLE
Bug in Postfix operators of sd_one_iterator

### DIFF
--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -210,7 +210,7 @@ class sd_one_iterator
             return *this;
         }
 
-        sd_one_iterator& operator++(int)
+        sd_one_iterator operator++(int)
         {
             sd_one_iterator result = *this;
             ++(*this);

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -226,7 +226,7 @@ class sd_one_iterator
             return *this;
         }
 
-        sd_one_iterator& operator--(int)
+        sd_one_iterator operator--(int)
         {
             sd_one_iterator result = *this;
             --(*this);


### PR DESCRIPTION
The postfix increment and decrement operators of sd_one_iterator
returns references to temporary local variables. Simple fix:
return copy instead of reference. The following code will seg
fault with the old function:

```
#include<sdsl/sd_vector.hpp>

int main() {
  sdsl::sd_vector_builder builder(20, 5);
  for (int i = 0; i < 10; i += 2)
    builder.set(i);
  sdsl::sd_vector<> s(builder);
  auto a = s.one_begin();
  auto b = a++;
  auto c = a--;
}
```