### PR TITLE
Make CMake 4 tolerate that libdivsufsort supports back to CMake 2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ if [[ ! -z "${CXX}" ]] ; then
     EXTRA_CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER="${CXX}")
 fi
 
-cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX="${SDSL_INSTALL_PREFIX}" "${EXTRA_CMAKE_ARGS[@]}" .. # run cmake 
+cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX="${SDSL_INSTALL_PREFIX}" "${EXTRA_CMAKE_ARGS[@]}" .. # run cmake 
 if [ $? != 0 ]; then
 	echo "ERROR: CMake build failed."
 	exit 1


### PR DESCRIPTION
CMake 4 has shipped in Homebrew, so we need to make sure we can still build vg dependencies even though it has started failing builds that declare compatibility back to versions older than 3.5.

Using the `3.5` value here also works with the `2.4.4` used in `libdivsufsort`.

See also: https://github.com/simongog/libdivsufsort/pull/2 which would bump the version requirement on the libdivsufsort we use.