### PR TITLE
Provide declarations for template specializations to remove Clang warning

### DIFF
--- a/include/sdsl/config.hpp
+++ b/include/sdsl/config.hpp
@@ -51,11 +51,21 @@ struct key_text_trait {
     static const char* KEY_TEXT;
 };
 
+template<>
+const char* key_text_trait<0>::KEY_TEXT;
+template<>
+const char* key_text_trait<8>::KEY_TEXT;
+
 //! Helper classes to transform width=0 and width=8 to corresponding bwt key
 template<uint8_t width>
 struct key_bwt_trait {
     static const char* KEY_BWT;
 };
+
+template<>
+const char* key_bwt_trait<0>::KEY_BWT;
+template<>
+const char* key_bwt_trait<8>::KEY_BWT;
 
 
 }


### PR DESCRIPTION
It's apparently [not actually allowed](https://stackoverflow.com/a/61151498) to specialize a template and then instantiate it, without telling other translation units that the template is getting specialized.

Clang warns about this, but it suggests you add a declaration of an *explicit instantiation* of the *un-specialized* template, since it assumes you are doing the allowed thing of instantiating an un-specialized template without telling the translation unit it's compiling.