### PR TITLE
Remove deprecated std::is_pod

### DIFF
--- a/include/sdsl/io.hpp
+++ b/include/sdsl/io.hpp
@@ -120,7 +120,7 @@ serialize(const X& x,
 }
 
 template<typename X>
-typename std::enable_if<std::is_pod<X>::value,uint64_t>::type
+typename std::enable_if<std::is_standard_layout<X>::value && std::is_trivial<X>::value,uint64_t>::type
 serialize(const X& x,
           std::ostream& out, structure_tree_node* v=nullptr,
           std::string name="")
@@ -148,7 +148,7 @@ load(X& x, std::istream& in)
 }
 
 template<typename X>
-typename std::enable_if<std::is_pod<X>::value,void>::type
+typename std::enable_if<std::is_standard_layout<X>::value && std::is_trivial<X>::value,void>::type
 load(X& x, std::istream& in)
 {
     read_member(x, in);


### PR DESCRIPTION
The warnings have finally gotten on my nerves enough.